### PR TITLE
feat: add semantic pull requests configuration

### DIFF
--- a/.github/semantic.yml
+++ b/.github/semantic.yml
@@ -1,0 +1,32 @@
+# Always validate the PR title, and ignore the commits
+titleOnly: false
+
+# Always validate all commits, and ignore the PR title
+commitsOnly: false
+
+# Always validate the PR title AND all the commits
+titleAndCommits: true
+
+# By default types specified in commitizen/conventional-commit-types is used.
+# See: https://github.com/commitizen/conventional-commit-types/blob/v3.0.0/index.json
+# You can override the valid types
+types:
+  - feat
+  - fix
+  - docs
+  - style
+  - refactor
+  - perf
+  - test
+  - build
+  - ci
+  - chore
+  - revert
+
+# Allow use of Merge commits (eg on github: "Merge branch 'master' into feature/ride-unicorns")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowMergeCommits: true
+
+# Allow use of Revert commits (eg on github: "Revert "feat: ride unicorns"")
+# this is only relevant when using commitsOnly: true (or titleAndCommits: true)
+allowRevertCommits: true


### PR DESCRIPTION
this github app enforces conventional commit messages
https://www.conventionalcommits.org/en/ 
the doc of the configuration can be found
https://github.com/zeke/semantic-pull-requests#configuration 


----

#

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/conflux-chain/sirius/1)
<!-- Reviewable:end -->
