### PR TITLE
fix(Notice): extract conflux rust version with simple replace

### DIFF
--- a/src/app/containers/HomePage/Notice.tsx
+++ b/src/app/containers/HomePage/Notice.tsx
@@ -22,8 +22,7 @@ export function Notice() {
   let v = useClientVersion();
   const loadingText = t(translations.general.loading);
 
-  const match = v?.match(/(\d+\.)?(\d+\.)?(\*|\d+)$/);
-  const version = (match && match[0]) || loadingText;
+  const version = (v && v?.replace('conflux-rust-', '')) || loadingText;
 
   const notices: React.ReactNode[] = [];
   for (const n in translations.notice) {


### PR DESCRIPTION
---

the old regex way can't extract versions like "1.0.0-alpha-5" from conflux-rust-1.0.0-alpha-5"
so we'll just use version.replace(conflux-rust-', '')